### PR TITLE
Ensure dashboard scales with window size

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -68,3 +68,17 @@ function updateLiveData() {
 
     liveChart.update();
 }
+
+function adjustLayout() {
+    const container = document.querySelector('.container');
+    if (container) {
+        container.style.width = `${window.innerWidth}px`;
+        container.style.height = `${window.innerHeight}px`;
+    }
+    if (liveChart) {
+        liveChart.resize();
+    }
+}
+
+window.addEventListener('resize', adjustLayout);
+document.addEventListener('DOMContentLoaded', adjustLayout);

--- a/data_analysis.js
+++ b/data_analysis.js
@@ -1,6 +1,8 @@
+let analysisChart;
+
 function loadData() {
     const ctx = document.getElementById('analysisChart').getContext('2d');
-    const analysisChart = new Chart(ctx, {
+    analysisChart = new Chart(ctx, {
         type: 'line',
         data: {
             labels: ['Lap 1', 'Lap 2', 'Lap 3', 'Lap 4', 'Lap 5'],
@@ -36,3 +38,17 @@ function loadData() {
         }
     });
 }
+
+function adjustLayout() {
+    const container = document.querySelector('.container');
+    if (container) {
+        container.style.width = `${window.innerWidth}px`;
+        container.style.height = `${window.innerHeight}px`;
+    }
+    if (analysisChart) {
+        analysisChart.resize();
+    }
+}
+
+window.addEventListener('resize', adjustLayout);
+document.addEventListener('DOMContentLoaded', adjustLayout);

--- a/lap_timing.js
+++ b/lap_timing.js
@@ -21,3 +21,14 @@ function resetLap() {
     lapStartTime = null;
     document.getElementById('lapTimes').innerHTML = '';
 }
+
+function adjustLayout() {
+    const container = document.querySelector('.container');
+    if (container) {
+        container.style.width = `${window.innerWidth}px`;
+        container.style.height = `${window.innerHeight}px`;
+    }
+}
+
+window.addEventListener('resize', adjustLayout);
+document.addEventListener('DOMContentLoaded', adjustLayout);

--- a/main.js
+++ b/main.js
@@ -207,6 +207,20 @@ setInterval(() => {
     }
 }, 15000);
 
+function adjustLayout() {
+    const container = document.querySelector('.container');
+    if (container) {
+        container.style.width = `${window.innerWidth}px`;
+        container.style.height = `${window.innerHeight}px`;
+    }
+    if (liveChart) {
+        liveChart.resize();
+    }
+}
+
+window.addEventListener('resize', adjustLayout);
+document.addEventListener('DOMContentLoaded', adjustLayout);
+
 document.getElementById('startButton').onclick = startDashboard;
 document.getElementById('stopButton').onclick = stopDashboard;
 document.getElementById('lapButton').onclick = recordLap;

--- a/styles.css
+++ b/styles.css
@@ -22,8 +22,8 @@
 body, html {
     margin: 0;
     padding: 0;
-    height: 100%;
-    width: 100%;
+    height: 100vh;
+    width: 100vw;
     font-family: 'Arial', sans-serif;
     background-color: var(--background-color); /* Background color */
     color: var(--text-color); /* Text color */
@@ -36,6 +36,7 @@ body, html {
     grid-template-rows: repeat(3, 1fr);
     gap: 10px;
     height: 100vh;
+    width: 100vw;
     padding: 10px;
     box-sizing: border-box;
 }
@@ -148,6 +149,8 @@ body, html {
     overflow: hidden;
     position: relative;
     color: var(--text-color); /* Text color within the chart container */
+    width: 100%;
+    height: 100%;
 }
 
 canvas {
@@ -257,6 +260,8 @@ ul {
     .container {
         grid-template-columns: 1fr;
         grid-template-rows: auto;
+        width: 100vw;
+        height: auto;
     }
 
     #liveData,


### PR DESCRIPTION
## Summary
- Use viewport-based dimensions so the base layout always fills the browser window.
- Stretch chart containers to occupy available space.
- Add resize handlers across scripts to update layout and chart sizes when the window changes.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893c7dccc648326924cd5692bc6ec40