### PR TITLE
feat: modernize dashboard with react and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Race Dashboard</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -31,72 +34,23 @@
         <!-- Live Data Section -->
         <div id="liveData" class="tile">
             <h2>Live Data</h2>
-            <div class="live-data-grid">
-                <div class="live-data-item">
-                    <i class="fas fa-tachometer-alt"></i>
-                    <span id="throttle">0%</span>
-                    <p>Throttle Position</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-car"></i>
-                    <span id="brake">Inactive</span>
-                    <p>Brake Status</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-thermometer-half"></i>
-                    <span id="ambientTemp">0°C</span>
-                    <p>Ambient Temperature</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-fire"></i>
-                    <span id="motorTemp">0°C</span>
-                    <p>Motor Temperature</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-tachometer-alt"></i>
-                    <span id="wheelSpeed">0 mph</span>
-                    <p>Wheel Speed</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-cogs"></i>
-                    <span id="motorRPM">0</span>
-                    <p>Motor RPM</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span id="gpsLongitude">0</span>
-                    <p>GPS Longitude</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span id="gpsLatitude">0</span>
-                    <p>GPS Latitude</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-flag-checkered"></i>
-                    <span id="lapNumber">0</span>
-                    <p>Lap Number</p>
-                </div>
-                <div class="live-data-item">
-                    <i class="fas fa-road"></i>
-                    <span id="distance">0 miles</span>
-                    <p>Distance</p>
-                </div>
-            </div>
+            <div id="liveDataRoot"></div>
         </div>
 
         <!-- Control Panel Section -->
         <div id="controlPanel" class="tile">
             <h2>Control Panel</h2>
             <button id="startButton" class="btn">Start</button>
-            <button id="stopButton" class="btn">Stop</button>
+            <button id="stopButton" class="btn" disabled>Stop</button>
             <button id="lapButton" class="btn">Lap</button>
             <label><input type="checkbox" id="spoofData"> Spoof Data</label>
+            <label><input type="checkbox" id="darkModeToggle"> Dark Mode</label>
         </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://kit.fontawesome.com/a076d05399.js"></script>
+    <script type="text/babel" src="liveData.jsx"></script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/liveData.jsx
+++ b/liveData.jsx
@@ -1,0 +1,49 @@
+const { useState, useEffect } = React;
+
+function LiveDataItem({ icon, value, label }) {
+  return (
+    <div className="live-data-item">
+      <i className={icon}></i>
+      <span>{value}</span>
+      <p>{label}</p>
+    </div>
+  );
+}
+
+function LiveDataGrid() {
+  const [data, setData] = useState({
+    throttle: '0%',
+    brake: 'Inactive',
+    ambientTemp: '0°C',
+    motorTemp: '0°C',
+    wheelSpeed: '0 mph',
+    motorRPM: '0',
+    gpsLongitude: '0',
+    gpsLatitude: '0',
+    lapNumber: '0',
+    distance: '0 miles'
+  });
+
+  useEffect(() => {
+    window.updateLiveDataState = (newData) => {
+      setData((prev) => ({ ...prev, ...newData }));
+    };
+  }, []);
+
+  return (
+    <div className="live-data-grid">
+      <LiveDataItem icon="fas fa-tachometer-alt" value={data.throttle} label="Throttle Position" />
+      <LiveDataItem icon="fas fa-car" value={data.brake} label="Brake Status" />
+      <LiveDataItem icon="fas fa-thermometer-half" value={data.ambientTemp} label="Ambient Temperature" />
+      <LiveDataItem icon="fas fa-fire" value={data.motorTemp} label="Motor Temperature" />
+      <LiveDataItem icon="fas fa-tachometer-alt" value={data.wheelSpeed} label="Wheel Speed" />
+      <LiveDataItem icon="fas fa-cogs" value={data.motorRPM} label="Motor RPM" />
+      <LiveDataItem icon="fas fa-map-marker-alt" value={data.gpsLongitude} label="GPS Longitude" />
+      <LiveDataItem icon="fas fa-map-marker-alt" value={data.gpsLatitude} label="GPS Latitude" />
+      <LiveDataItem icon="fas fa-flag-checkered" value={data.lapNumber} label="Lap Number" />
+      <LiveDataItem icon="fas fa-road" value={data.distance} label="Distance" />
+    </div>
+  );
+}
+
+ReactDOM.render(<LiveDataGrid />, document.getElementById('liveDataRoot'));

--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ let liveChartData = {
 let lastWheelSpeed = 60; // Initial wheel speed
 let lastMotorRPM = 3000; // Initial motor RPM
 let chartNeedsUpdate = false; // Flag to indicate chart update
+let distance = 0; // Distance traveled in miles
 
 function startDashboard() {
     isRunning = true;
@@ -32,11 +33,16 @@ function startDashboard() {
     initializeChart();
     startSpoofing();
     requestAnimationFrame(updateChart);
+    document.getElementById('startButton').disabled = true;
+    document.getElementById('stopButton').disabled = false;
+    distance = 0;
 }
 
 function stopDashboard() {
     isRunning = false;
     logDebug('Dashboard stopped');
+    document.getElementById('startButton').disabled = false;
+    document.getElementById('stopButton').disabled = true;
 }
 
 function initializeChart() {
@@ -65,14 +71,32 @@ function initializeChart() {
 
 function updateLiveData() {
     const currentTime = new Date().toLocaleTimeString();
-    
+
     // Generate new data with small variations from the last data points
     lastWheelSpeed = Math.max(0, lastWheelSpeed + (Math.random() * 4 - 2)); // +/- 2 mph variation
     lastMotorRPM = Math.max(0, lastMotorRPM + (Math.random() * 200 - 100)); // +/- 100 RPM variation
+    distance += lastWheelSpeed / 3600; // convert mph to miles per second
+    const throttle = Math.random() * 100;
+    const brakeActive = Math.random() > 0.8;
+    const ambientTemp = 20 + Math.random() * 10;
+    const motorTemp = 60 + Math.random() * 20;
+    const gpsLongitude = -0.1 + Math.random() * 0.2;
+    const gpsLatitude = 51.5 + Math.random() * 0.2;
 
-    // Update the live data fields
-    document.getElementById('wheelSpeed').textContent = lastWheelSpeed.toFixed(1) + ' mph';
-    document.getElementById('motorRPM').textContent = lastMotorRPM.toFixed(0);
+    if (window.updateLiveDataState) {
+        window.updateLiveDataState({
+            wheelSpeed: `${lastWheelSpeed.toFixed(1)} mph`,
+            motorRPM: `${lastMotorRPM.toFixed(0)}`,
+            throttle: `${throttle.toFixed(0)}%`,
+            brake: brakeActive ? 'Active' : 'Inactive',
+            ambientTemp: `${ambientTemp.toFixed(1)}°C`,
+            motorTemp: `${motorTemp.toFixed(1)}°C`,
+            gpsLongitude: gpsLongitude.toFixed(5),
+            gpsLatitude: gpsLatitude.toFixed(5),
+            lapNumber: lapNumber.toString(),
+            distance: `${distance.toFixed(2)} miles`
+        });
+    }
 
     // Update the chart data
     liveChartData.labels.push(currentTime);
@@ -111,6 +135,9 @@ function recordLap() {
     lapNumber++;
     addLapButton(lapNumber);
     logDebug(`Lap ${lapNumber} recorded`);
+    if (window.updateLiveDataState) {
+        window.updateLiveDataState({ lapNumber: lapNumber.toString() });
+    }
 }
 
 function addLapButton(lapNumber) {
@@ -225,3 +252,6 @@ document.getElementById('startButton').onclick = startDashboard;
 document.getElementById('stopButton').onclick = stopDashboard;
 document.getElementById('lapButton').onclick = recordLap;
 document.getElementById('spoofData').onchange = startSpoofing;
+document.getElementById('darkModeToggle').onchange = (e) => {
+    document.body.classList.toggle('dark-mode', e.target.checked);
+};

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,22 @@
     --scrollbar-thumb-debug-hover-color: #a94442; /* Darker red for hover */
 }
 
+body.dark-mode {
+    --background-color: #1e1e1e;
+    --text-color: #ffffff;
+    --tile-background-color: #2b2b2b;
+    --tile-border-color: #444444;
+    --button-background-color: #3a3f7a;
+    --button-hover-color: #565a80;
+    --debug-background-color: #5c1b20;
+    --debug-text-color: #f8d7da;
+    --scrollbar-bg-color: #1e1e1e;
+    --scrollbar-thumb-color: #3a3f7a;
+    --scrollbar-thumb-hover-color: #565a80;
+    --scrollbar-thumb-debug-color: #f8d7da;
+    --scrollbar-thumb-debug-hover-color: #f5c6cb;
+}
+
 body, html {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## Summary
- render live telemetry via a new React-based component
- wire up start/stop controls and dark mode toggle for a smoother UX
- streamline styling with CSS variables and dark theme values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ca106adc832690d0fc9b4d004bbf