### PR TITLE
feat: add in-page lap overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,19 @@
         </div>
     </div>
 
+    <!-- Lap Overlay -->
+    <div id="lapOverlay" class="overlay">
+        <div class="overlay-content">
+            <div class="overlay-header">
+                <h1 id="lapTitle">Lap</h1>
+                <button id="closeLapOverlay" class="btn">Close</button>
+            </div>
+            <div class="chart-container">
+                <canvas id="lapChart"></canvas>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://kit.fontawesome.com/a076d05399.js"></script>
     <script type="text/babel" src="liveData.jsx"></script>

--- a/main.js
+++ b/main.js
@@ -151,61 +151,52 @@ function addLapButton(lapNumber) {
 }
 
 function openLapWindow(lapNumber) {
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-    const newWindow = window.open('', '', `width=${width},height=${height}`);
+    const overlay = document.getElementById('lapOverlay');
+    document.getElementById('lapTitle').textContent = `Lap ${lapNumber}`;
+    overlay.style.display = 'flex';
 
-    const lap = lapNumber;
+    const ctx = document.getElementById('lapChart').getContext('2d');
+    if (window.lapChart) {
+        window.lapChart.destroy();
+    }
 
-    newWindow.document.write(`
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Lap ${lapNumber}</title>
-            <link rel="stylesheet" href="styles.css">
-            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-        </head>
-        <body>
-            <div class="lap-window">
-                <h1>Lap ${lapNumber}</h1>
-                <button onclick="window.close()">Close</button>
-                <div class="chart-container">
-                    <canvas id="lapChart"></canvas>
-                </div>
-            </div>
-            <script>
-                const ctx = document.getElementById('lapChart').getContext('2d');
-                new Chart(ctx, {
-                    type: 'line',
-                    data: {
-                        labels: ${JSON.stringify(liveChartData.labels)},
-                        datasets: ${JSON.stringify(liveChartData.datasets)}
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        scales: {
-                            x: {
-                                ticks: {
-                                    maxRotation: 90,
-                                    minRotation: 90
-                                }
-                            },
-                            y: {
-                                beginAtZero: true
-                            }
-                        }
+    const labels = [...liveChartData.labels];
+    const datasets = liveChartData.datasets.map(ds => ({
+        ...ds,
+        data: [...ds.data]
+    }));
+
+    window.lapChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels,
+            datasets
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                x: {
+                    ticks: {
+                        maxRotation: 90,
+                        minRotation: 90
                     }
-                });
-            </script>
-        </body>
-        </html>
-    `);
+                },
+                y: {
+                    beginAtZero: true
+                }
+            }
+        }
+    });
+}
 
-    newWindow.document.close();
-    newWindow.focus();
+function closeLapOverlay() {
+    const overlay = document.getElementById('lapOverlay');
+    overlay.style.display = 'none';
+    if (window.lapChart) {
+        window.lapChart.destroy();
+        window.lapChart = null;
+    }
 }
 
 function logDebug(message, isAlert = false) {
@@ -255,3 +246,4 @@ document.getElementById('spoofData').onchange = startSpoofing;
 document.getElementById('darkModeToggle').onchange = (e) => {
     document.body.classList.toggle('dark-mode', e.target.checked);
 };
+document.getElementById('closeLapOverlay').onclick = closeLapOverlay;

--- a/styles.css
+++ b/styles.css
@@ -299,3 +299,44 @@ ul {
         max-height: none; /* Allow full height for small screens */
     }
 }
+
+/* Lap overlay styles */
+#lapOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+#lapOverlay .overlay-content {
+    background-color: var(--tile-background-color);
+    color: var(--text-color);
+    padding: 10px;
+    border-radius: 10px;
+    width: 80%;
+    height: 80%;
+    display: flex;
+    flex-direction: column;
+}
+
+#lapOverlay .overlay-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+#lapOverlay .chart-container {
+    flex: 1;
+}
+
+#lapOverlay canvas {
+    width: 100% !important;
+    height: 100% !important;
+}


### PR DESCRIPTION
## Summary
- add modal overlay for lap charts to avoid extra windows
- style overlay for consistency with dashboard
- integrate overlay logic in main script with close handler

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6893cc68aa0c83268e14ef45290a06e5